### PR TITLE
WIP: Add .indexignore support.

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -41,6 +41,9 @@ module.exports.dir = {
 		files = files.filter((file) => {
 			if(['.', '$'].includes(file[0]) || file.includes('#'))
 			{
+				if (file === '.indexignore'){
+					return true;
+				};
 				return false;
 			} else {
 				return true;

--- a/src/functions.js
+++ b/src/functions.js
@@ -37,13 +37,12 @@ module.exports.dir = {
 		/* Read directory. */
 		var files = await fsp.readdir(_path);
 
-		/* Hide hidden files, invalid filenames (#) and (some) windows specific directories ($). */
-		files = files.filter((file) => {
-			if(['.', '$'].includes(file[0]) || file.includes('#'))
+		/* Filter out hidden files (.), invalid filenames (#) and (some) windows specific directories ($). */
+		files = files.filter((file) =>
+		{
+			if((['.', '$'].includes(file[0]) || file.includes('#'))
+				&& file !== '.indexignore')
 			{
-				if (file === '.indexignore'){
-					return true;
-				}
 				return false;
 			} else {
 				return true;
@@ -426,6 +425,15 @@ module.exports.trim = {
 module.exports.addTrailing = (s, char) =>
 {
 	return s.endsWith(char) ? s : (s + char);
+};
+
+/** Converts a wildcard string into a regular expression. */
+module.exports.wildcardExpression = (wildcard) =>
+{
+	/** Escape input and create new regex expression. */
+	var escaped = wildcard.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+
+	return new RegExp(`^${escaped.replace(/\*/g,'.*').replace(/\?/g,'.')}$`,'i');
 };
 
 /* Adds a leading character to a string if it does not already exist. */

--- a/src/functions.js
+++ b/src/functions.js
@@ -43,7 +43,7 @@ module.exports.dir = {
 			{
 				if (file === '.indexignore'){
 					return true;
-				};
+				}
 				return false;
 			} else {
 				return true;

--- a/src/functions.js
+++ b/src/functions.js
@@ -433,7 +433,7 @@ module.exports.wildcardExpression = (wildcard) =>
 	/** Escape input and create new regex expression. */
 	var escaped = wildcard.replace(/[.+^${}()|[\]\\]/g, '\\$&');
 
-	return new RegExp(`^${escaped.replace(/\*/g,'.*').replace(/\?/g,'.')}$`,'i');
+	return new RegExp(`^${escaped.replace(/\*/g,'.*')}$`);
 };
 
 /* Adds a leading character to a string if it does not already exist. */

--- a/src/nodexer.js
+++ b/src/nodexer.js
@@ -77,7 +77,6 @@ const handle = async (directory, req, res, next, executed = null) =>
 			}
 
 			/* Check for `.indexignore` file. */
-			var ignoreContent = null;
 			var ignore = await data.contents.files.find(file => file.name === '.indexignore');
 
 			/** If `.indexignore` is present. */
@@ -110,7 +109,7 @@ const handle = async (directory, req, res, next, executed = null) =>
 							break;
 						}
 
-						if(fileObject.hasOwnProperty(input))
+						if(Object.prototype.hasOwnProperty.call(fileObject, input))
 						{
 							fileObject[input].hidden = true;
 						} else if(input.includes('*'))

--- a/src/nodexer.js
+++ b/src/nodexer.js
@@ -85,10 +85,8 @@ const handle = async (directory, req, res, next, executed = null) =>
 				/** Store file objects and keys. */
 				var fileObject = {}, fileKeys = {};
 
-				(data.contents.files.concat(data.contents.directories)).forEach((file) =>
-				{
-					fileObject[file.name] = file;
-				});
+				(data.contents.files).forEach((file) => fileObject[file.name] = file);
+				(data.contents.directories).forEach((file) => fileObject[file.name + '/'] = file);
 				
 				fileKeys = Object.keys(fileObject);
 

--- a/src/nodexer.js
+++ b/src/nodexer.js
@@ -76,6 +76,24 @@ const handle = async (directory, req, res, next, executed = null) =>
 				}
 			}
 
+			/* Check for .indexignore */
+			var ignoreContent = null;
+
+			var ignore = await data.contents.files.find(file => file.name === '.indexignore')
+
+			if (ignore) {
+				await fsp.readFile(path.join(directory, ignore.relative), 'utf8').then(fileBuffer => {
+					ignoreContent = fileBuffer.toString();
+					var arr = ignoreContent.split('\n')
+
+					arr.forEach(element => {
+						var ignoredFile = data.contents.files.find(file => file.name === element)
+						ignoredFile.hidden = true
+					})
+				})
+				ignore.hidden = true
+			}
+
 			/* Collected data has some value stored in a 'raw' key that we need to access. */
 			var raw = ['size', 'modified'].includes(user.sorting.sort_by) ? true : false;
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -46,18 +46,19 @@ body.directory(class=config.style.compact == true ? 'compact' : '')
       td -
       td -
     each dir in contents.directories
-      tr.directory
-        td
-          a(href=dir.relative) [#{dir.name}]
-        td(data-raw=dir.modified.raw)
-          span
-            span(data-view='desktop')=dir.modified.formatted[0]
-            span(data-view='mobile')=dir.modified.formatted[1]
-        td -
-        td -
+      if !dir.hidden
+        tr.directory
+          td
+            a(href=dir.relative) [#{dir.name}]
+          td(data-raw=dir.modified.raw)
+            span
+              span(data-view='desktop')=dir.modified.formatted[0]
+              span(data-view='mobile')=dir.modified.formatted[1]
+          td -
+          td -
     each file in contents.files
-      tr.file
-        if !file.hidden
+      if !file.hidden
+        tr.file
           td(data-raw=file.name)
             if file.media == true
               a.preview(href=file.relative)=file.name


### PR DESCRIPTION
This feature works similarly to `.gitignore` within git. Currently only works with files, not dirs.
Planned to have similar functionality as `.gitignore` if possible.

Working:
- Does not index **files** if they are in `.indexignore` - same strucure as `.gitignore` - 1 file per line

Todo:
- Work with directories
- Config toggle?
- \* modifer

Possible:
- Regex?