### PR TITLE
Description meta tag support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ivfi",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ivfi",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "GPL-3.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/src/core/types/init-options/index.ts
+++ b/src/core/types/init-options/index.ts
@@ -27,6 +27,7 @@ export type TOptions = {
 		enabled?: boolean;
 		hidden?: boolean;
 		toggled?: boolean;
+		meta?: boolean;
 	};
 	media?: {
 		extensions?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,23 +127,33 @@ const handle = async (
 
 			/** Collect and read `README.md` file */
 			let readmeContent = null;
+      let readmeText = null;
+      let readmePreview = null;
 
-			if(config.server.readme.enabled)
-			{
-				/** Check for a `README.md` file */
-				const readme = await data.contents.files.find(file => file.name === 'README.md');
-
-				if(readme)
-				{
-					/** Read `README.md` file */
-					await fsp.readFile(path.join(directory, readme.relative), 'utf8').then(fileBuffer => {
-						readmeContent = converter.makeHtml(fileBuffer.toString());
-					});
-
-					/** Set hidden state if enabled */
-					readme.hidden = config.server.readme.hidden ? true: false;
-				}
-			}
+			if (config.server.readme.enabled) {
+        /** Check for a `README.md` file */
+        const readme = await data.contents.files.find(
+          (file) => file.name === "README.md"
+        );
+    
+        if (readme) {
+          /** Read `README.md` file */
+          await fsp
+            .readFile(path.join(directory, readme.relative), "utf8")
+            .then((fileBuffer) => {
+              readmeText = fileBuffer.toString();
+              readmeContent = converter.makeHtml(fileBuffer.toString());
+            });
+    
+          if (config.server.readme.meta == true) {
+            readmePreview = readmeText.replaceAll(/<\/?[^>]+(>|$)/gi, "").replace(/\s+/g, ' ').trim();
+            console.log(readmePreview)
+          }
+    
+          /** Set hidden state if enabled */
+          readme.hidden = config.server.readme.hidden ? true : false;
+        }
+      }
 
 			/** Check for `.indexignore` file */
 			const ignore = await data.contents.files.find(file => file.name === '.indexignore');
@@ -231,6 +241,7 @@ const handle = async (
 				path: clickablePath(relative),
 				readme: {
 					content: readmeContent,
+          preview: readmePreview,
 					toggled: !clientConfig.readme.toggled
 				},
 				req: relative,

--- a/src/options.ts
+++ b/src/options.ts
@@ -50,7 +50,8 @@ const data: TOptions = {
 	readme: {
 		enabled: true,
 		hidden: false,
-		toggled: true
+		toggled: true,
+		meta: true
 	},
 	media: {
 		extensions: {

--- a/views/index.pug
+++ b/views/index.pug
@@ -8,6 +8,11 @@ head
     content='width=device-width, initial-scale=1'
   )
   title Index of #{req}
+  if readme.preview
+    meta(
+      name='description'
+      content=readme.preview
+    )
   link(
     rel='shortcut icon'
     type=(config.icon.mime || 'image/png')


### PR DESCRIPTION
Inital PoC that creates a description meta tag from the contents of the readme. Regex is terrible and I'm not sure how I feel about the whole solution but let me know what you think....

Enable it:
```js
const options = {
  debug: true,
  readme: {
    meta: true
  }
}
```