### PR TITLE
Add support for directory-specific configuration files (`.ivfi` dotfiles)

### DIFF
--- a/src/core/helpers/node/common.ts
+++ b/src/core/helpers/node/common.ts
@@ -20,7 +20,7 @@ export const asyncForEach = async (array: any[], callback: any) =>
 /**
  * Calculates render time (process.hrtime())
  */
-export const getExecutionTime = (t) =>
+export const getExecutionTime = (t: [number, number]) =>
 {
 	return (t[0] + (t[1] / 1e9)).toFixed(6);
 };
@@ -28,7 +28,7 @@ export const getExecutionTime = (t) =>
 /**
  * Converts a wildcard string into a regular expression
  */
-export const wildcardExpression = (wildcard) =>
+export const wildcardExpression = (wildcard: string) =>
 {
 	/** Escape input and create new regex expression */
 	const escaped = wildcard.replace(/[.+^${}()|[\]\\]/g, '\\$&');
@@ -39,7 +39,7 @@ export const wildcardExpression = (wildcard) =>
 /**
  * Checks if a path is above another path
  */
-export const isAbovePath = (base, path) =>
+export const isAbovePath = (base: string, path: string) =>
 {
 	const b = path.startsWith(base);
 

--- a/src/core/helpers/node/dirUtils.ts
+++ b/src/core/helpers/node/dirUtils.ts
@@ -117,7 +117,7 @@ const dirCollect = async (
 
 			files.push({
 				basename: file.basename,
-				extension: file.extension,
+				extension: file.extension.toLowerCase(),
 				directory: !stats.isFile() ? true : false,
 				stats: stats
 			});
@@ -185,6 +185,7 @@ const dirCollect = async (
 			hidden: false,
 			relative: path.join(pathInfo.relative, (file.basename)).replace(/\\/g, '/'),
 			name: file.basename,
+			extension: (!file.directory ? file.extension : null) || null,
 			size: size,
 			modified: {
 				raw: modified,

--- a/src/core/helpers/node/dirUtils.ts
+++ b/src/core/helpers/node/dirUtils.ts
@@ -4,6 +4,10 @@ import { promises as fsp } from 'fs';
 import { options } from '../../../options';
 
 import {
+	TFileContent
+} from '../../types';
+
+import {
 	getReadableSize,
 	calculateOffset,
 	gmdate
@@ -25,8 +29,8 @@ type TFile = {
 
 type TCollected = {
 	contents: {
-		files: any[];
-		directories: any[];
+		files: Array<TFileContent>;
+		directories: Array<TFileContent>;
 	};
 	stats: {
 		total: {
@@ -48,7 +52,7 @@ const dirScan = async (path: string, _options: TOptions = {}): Promise<TFile[]> 
 	})).forEach((dirEnt =>
 	{
 		if(!((['.', '$'].includes(dirEnt.name[0]) || dirEnt.name.includes('#'))
-			&& dirEnt.name !== '.indexignore'))
+			&& dirEnt.name !== '.ivfi'))
 		{
 			files.push({
 				basename: dirEnt.name,
@@ -83,7 +87,7 @@ const dirCollect = async (
 	} = {}
 ): Promise<TCollected> =>
 {
-	const data = {
+	const data: TCollected = {
 		contents: {
 			files: [],
 			directories: []
@@ -181,7 +185,7 @@ const dirCollect = async (
 			hidden: false,
 			relative: path.join(pathInfo.relative, (file.basename)).replace(/\\/g, '/'),
 			name: file.basename,
-			size,
+			size: size,
 			modified: {
 				raw: modified,
 				formatted

--- a/src/core/helpers/node/dotFileUtils.ts
+++ b/src/core/helpers/node/dotFileUtils.ts
@@ -1,4 +1,5 @@
 import {
+    mergeMetadata,
     wildcardExpression
 } from './index';
 
@@ -74,68 +75,20 @@ export const handleDotFile = (config: TDotFile, data: {
             ? (config.metadataBehavior as string).toLowerCase()
             : 'overwrite';
 
-        /** Store metadata */
-        const mdMerge: {
-            [key: string]: {
-                [key: string]: string;
-            }
-        } = {};
-
         if(behavior === 'overwrite')
         {
-            /** Iterate over and store current metadata */
-            data.metadata.forEach((item) =>
-            {
-                Object.keys(item).forEach((key) =>
-                {
-                    if(key !== 'content')
-                    {
-                        if(!mdMerge[key]) mdMerge[key] = {};
-
-                        mdMerge[key][item[key]] = item.content;
-                    }
-                });
-            });
-
-            /**
-             * Iterate over new, directory-specific metadata
-             * 
-             * This will override any existing values, but still keep any unchanged values
-             */
-            (config.metadata as Array<{ [key: string]: string; }>).forEach((item) =>
-            {
-                Object.keys(item).forEach((key) =>
-                {
-                    if(key !== 'content')
-                    {
-                        if(!mdMerge[key]) mdMerge[key] = {};
-
-                        mdMerge[key][item[key]] = (item as {
-                            [key: string]: string;
-                        }).content || null;
-                    }
-                });
-            });
-
-            /** Set new metadata */
-            data.setMetadata(Object.keys(mdMerge).map((property) =>
-            {
-                return Object.keys(mdMerge[property]).map((key) =>
-                {
-                    const item = { [property]: key };
-
-                    if(mdMerge[property][key])
-                    {
-                        item.content = mdMerge[property][key];
-                    }
-
-                    return item;
-                });
-            }).flatMap((item) => item) as TMetaData);
+            /** Set new metadata by merging */
+            data.setMetadata(
+                mergeMetadata(
+                    data.metadata as TMetaData, config.metadata as TMetaData
+                )
+            );
         } else if(behavior === 'replace')
         {
-            /** Set new metadata */
-            data.setMetadata(config.metadata as TMetaData);
+            /** Set new metadata by replacement */
+            data.setMetadata(
+                config.metadata as TMetaData
+            );
         }
     }
 };

--- a/src/core/helpers/node/dotFileUtils.ts
+++ b/src/core/helpers/node/dotFileUtils.ts
@@ -1,0 +1,141 @@
+import {
+    wildcardExpression
+} from './index';
+
+import {
+    TDotFile,
+    TFileContent,
+    TMetaData
+} from '../../types';
+
+const ignoreFiles = (data: any, filter: Array<string>) =>
+{
+    /** Store file objects and keys */
+    const fileObject = {};
+
+    /** Get all files and directories */
+    (data.files).forEach((file: any) => fileObject[file.name] = file);
+    (data.directories).forEach((dir: any) => fileObject[dir.name + '/'] = dir);
+
+    /** Get file keys */
+    const fileKeys = Object.keys(fileObject);
+
+    for(let i = 0; i < (filter).length; i++)
+    {
+        const ignoreItem = filter[i] as string;
+
+        if(!ignoreItem) continue;
+
+        if(Object.prototype.hasOwnProperty.call(fileObject, ignoreItem))
+        {
+            fileObject[ignoreItem].hidden = true;
+        } else if(ignoreItem.includes('*'))
+        {
+            /** Escape input and create new regular expression */
+            const ignoreRegex = wildcardExpression(ignoreItem);
+
+            (fileKeys).forEach((key) =>
+            {
+                if(ignoreRegex.test(key))
+                {
+                    fileObject[key].hidden = true;
+                }
+            });
+        }
+    }
+};
+
+export const handleDotFile = (config: TDotFile, data: {
+    files: Array<TFileContent>,
+    directories: Array<TFileContent>,
+    metadata: TMetaData,
+    setMetadata: (data: TMetaData) => void
+}) =>
+{
+    /**	Handle ignored files */
+    if(config.ignore
+        && Array.isArray(config.ignore)
+        && config.ignore.length > 0)
+    {
+        ignoreFiles(
+            {
+                files: data.files,
+                directories: data.directories
+            },
+            config.ignore as Array<string>
+        );
+    }
+
+    /** Handle metadata */
+    if(config.metadata)
+    {
+        /** Get behavior */
+        const behavior = config.metadataBehavior
+            ? (config.metadataBehavior as string).toLowerCase()
+            : 'overwrite';
+
+        /** Store metadata */
+        const mdMerge: {
+            [key: string]: {
+                [key: string]: string;
+            }
+        } = {};
+
+        if(behavior === 'overwrite')
+        {
+            /** Iterate over and store current metadata */
+            data.metadata.forEach((item) =>
+            {
+                Object.keys(item).forEach((key) =>
+                {
+                    if(key !== 'content')
+                    {
+                        if(!mdMerge[key]) mdMerge[key] = {};
+
+                        mdMerge[key][item[key]] = item.content;
+                    }
+                });
+            });
+
+            /**
+             * Iterate over new, directory-specific metadata
+             * 
+             * This will override any existing values, but still keep any unchanged values
+             */
+            (config.metadata as Array<{ [key: string]: string; }>).forEach((item) =>
+            {
+                Object.keys(item).forEach((key) =>
+                {
+                    if(key !== 'content')
+                    {
+                        if(!mdMerge[key]) mdMerge[key] = {};
+
+                        mdMerge[key][item[key]] = (item as {
+                            [key: string]: string;
+                        }).content || null;
+                    }
+                });
+            });
+
+            /** Set new metadata */
+            data.setMetadata(Object.keys(mdMerge).map((property) =>
+            {
+                return Object.keys(mdMerge[property]).map((key) =>
+                {
+                    const item = { [property]: key };
+
+                    if(mdMerge[property][key])
+                    {
+                        item.content = mdMerge[property][key];
+                    }
+
+                    return item;
+                });
+            }).flatMap((item) => item) as TMetaData);
+        } else if(behavior === 'replace')
+        {
+            /** Set new metadata */
+            data.setMetadata(config.metadata as TMetaData);
+        }
+    }
+};

--- a/src/core/helpers/node/index.ts
+++ b/src/core/helpers/node/index.ts
@@ -6,6 +6,7 @@ export * from './dirUtils';
 export * from './configUtils';
 export * from './dotFileUtils';
 export * from './mergeExisting';
+export * from './mergeMetadata';
 export * from './clickablePath';
 export * from './sortByKey';
 export * from './themeLoader';

--- a/src/core/helpers/node/index.ts
+++ b/src/core/helpers/node/index.ts
@@ -4,6 +4,7 @@
 export * from './common';
 export * from './dirUtils';
 export * from './configUtils';
+export * from './dotFileUtils';
 export * from './mergeExisting';
 export * from './clickablePath';
 export * from './sortByKey';

--- a/src/core/helpers/node/mergeMetadata.ts
+++ b/src/core/helpers/node/mergeMetadata.ts
@@ -1,0 +1,48 @@
+import {
+    TMetaData
+} from '../../types';
+
+/**
+ * Merges a metadata array with another metadata array
+ */
+export const mergeMetadata = (source: TMetaData, data: TMetaData) =>
+{
+    const metadata: {
+        [key: string]: {
+            [key: string]: string;
+        }
+    } = {};
+
+    /** Iterate over and store current metadata */
+    for(const item of source)
+    {
+        for (const [key, value] of Object.entries(item)) {
+            if(key !== 'content')
+            {
+                if(!(key in metadata)) metadata[key] = {};
+                metadata[key][value as string] = item.content;
+            }
+        }
+    }
+
+    /** Iterate over new, directory-specific metadata, overwrite when needed */
+    for(const { content, ...rest } of data)
+    {
+        for(const [key, value] of Object.entries(rest))
+        {
+            if(key !== 'content')
+            {
+                if(!metadata.hasOwnProperty(key)) metadata[key] = {};
+                metadata[key][value as string] = content || null;
+            }
+        }
+    }
+
+    /** Create and return metadata array */
+    return Object.entries(metadata).flatMap(([property, values]) =>
+        Object.entries(values).map(([key, content]) => (
+        {
+            [property]: key, ...(content && { content })
+        }))
+    );
+};

--- a/src/core/helpers/node/mergeMetadata.ts
+++ b/src/core/helpers/node/mergeMetadata.ts
@@ -9,31 +9,44 @@ export const mergeMetadata = (source: TMetaData, data: TMetaData) =>
 {
     const metadata: {
         [key: string]: {
-            [key: string]: string;
+            [key: string]: string | boolean;
         }
     } = {};
 
     /** Iterate over and store current metadata */
     for(const item of source)
     {
-        for (const [key, value] of Object.entries(item)) {
+        for (const [key, value] of Object.entries(item))
+        {
             if(key !== 'content')
             {
-                if(!(key in metadata)) metadata[key] = {};
-                metadata[key][value as string] = item.content;
+                /** Reset object if no content is present, or create on unexisting key */
+                if(item.content === false
+                    || !Object.prototype.hasOwnProperty.call(metadata, key))
+                {
+                    metadata[key] = {};
+                }
+                
+                metadata[key][value as string] = item.content || false;
             }
         }
     }
 
-    /** Iterate over new, directory-specific metadata, overwrite when needed */
-    for(const { content, ...rest } of data)
+    /** Iterate over new metadata, overwrite when needed */
+    for(const { content = false, ...rest } of data)
     {
         for(const [key, value] of Object.entries(rest))
         {
             if(key !== 'content')
             {
-                if(!metadata.hasOwnProperty(key)) metadata[key] = {};
-                metadata[key][value as string] = content || null;
+                /** Reset object if no content is present, or create on unexisting key */
+                if(content === false
+                    || !Object.prototype.hasOwnProperty.call(metadata, key))
+                {
+                    metadata[key] = {};
+                }
+
+                metadata[key][value as string] = content || false;
             }
         }
     }

--- a/src/core/types/common/index.ts
+++ b/src/core/types/common/index.ts
@@ -70,7 +70,7 @@ export type TFileContent = {
 
 /** Metadata array */
 export type TMetaData = Array<{
-	[key: string]: string;
+	[key: string]: string | boolean;
 }>;
 
 /**

--- a/src/core/types/common/index.ts
+++ b/src/core/types/common/index.ts
@@ -58,6 +58,7 @@ export type TFileContent = {
 	hidden: boolean;
 	relative: string;
 	name: string;
+	extension: string;
 	size: {
 		raw: number;
 		readable?: string;

--- a/src/core/types/common/index.ts
+++ b/src/core/types/common/index.ts
@@ -50,6 +50,39 @@ export type TExtensionArray = {
 };
 
 /**
+ * File object passed to the renderer
+ */
+export type TFileContent = {
+	media: boolean;
+	type: string;
+	hidden: boolean;
+	relative: string;
+	name: string;
+	size: {
+		raw: number;
+		readable?: string;
+	};
+	modified: {
+		raw: number;
+		formatted: Array<string>;
+	};
+};
+
+/** Metadata array */
+export type TMetaData = Array<{
+	[key: string]: string;
+}>;
+
+/**
+ * Dotfile configuration (.ivfi files)
+ */
+export type TDotFile = {
+	[key: string]: Array<string
+			| { [key: string]: string; }>
+		| string;
+};
+
+/**
  * `galleryItemChanged` event data
  */
 export type TPayloadgalleryItemChanged = {
@@ -64,11 +97,11 @@ export type TPayloadgalleryItemChanged = {
  */
 export interface IWindowGlobals extends Window {
 	eventHooks?: EventTargetEventHooks['eventHooks'];
-}
+};
 
 /**
  * Global `document` extensions
  */
 export interface IDocumentGlobals extends Document {
 	eventHooks?: EventTargetEventHooks['eventHooks'];
-}
+};

--- a/src/core/types/init-options/index.ts
+++ b/src/core/types/init-options/index.ts
@@ -60,6 +60,6 @@ export type TOptions = {
 		key: string;
 		cert: string;
 	};
-	exclude?: boolean;
+	exclude?: boolean | Array<string>;
 	debug?: boolean;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ import {
 	getReadableSize,
 	calculateOffset,
 	trimRight,
-	addLeading
+	addLeading,
+	addTrailing
 } from './core/helpers/';
 
 /** Helpers */
@@ -216,7 +217,7 @@ const handle = async (
 					content: readmeContent,
 					toggled: !clientConfig.readme.toggled
 				},
-				req: relative,
+				req: addTrailing(relative, '/'),
 				parent: addLeading(relative.substring(0, relative.lastIndexOf('/')), '/'),
 				count: {
 					files: contents.files.length,
@@ -228,6 +229,7 @@ const handle = async (
 					},
 					newest: data.stats.newest
 				},
+				dotfile: dotFile || false,
 				metadata: metadata,
 				rendered: getExecutionTime(process.hrtime(executed))
 			};

--- a/src/index.ts
+++ b/src/index.ts
@@ -451,6 +451,8 @@ const ivfi = (workingDirectory: string = path.join(__dirname, '..')) =>
 				config.server.metadata = null;
 			}
 
+			let customIconURI = null;
+
 			/** Handle custom favicon */
 			if(_.has(_options, 'icon.file') && _.isString(_options.icon.file))
 			{
@@ -472,14 +474,15 @@ const ivfi = (workingDirectory: string = path.join(__dirname, '..')) =>
 					/** Set favicon path */
 					config.server.icon.path = iconUri;
 
+					customIconURI = iconUri;
+
 					app.get(iconUri, (req: Request, res: Response, next: NextFunction) =>
 					{
 						res.sendFile(path.resolve(iconPath), (error) =>
 						{
 							if(error)
 							{
-								res.status(500).end();
-								next();
+								res.status(404).render('errors/404');
 							}
 						});
 					});
@@ -491,6 +494,11 @@ const ivfi = (workingDirectory: string = path.join(__dirname, '..')) =>
 			/** Handle any incoming requests */
 			app.get('(/*)?', (req: Request, res: Response, next: NextFunction) =>
 			{
+				if(customIconURI && req.path === customIconURI)
+				{
+					return;
+				}
+
 				handle(module.directory, req, res, next, process.hrtime());
 			});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,8 @@ import {
 	loadThemes,
 	cookieRead,
 	debug,
-	logger
+	logger,
+	mergeMetadata
 } from './core/helpers/node/';
 
 /** Markdown converter */
@@ -101,8 +102,17 @@ const handle = async (
 			debug(chalk.yellow(`Navigating: ${chalk.green(`'${relative}'`)} ...`));
 
 			/** Overridable data passed to the renderer */
-			let readmeContent = null;
-			let metadata = config.server.metadata || null;
+			let readmeContent: null | string = null;
+			let metadata: TMetaData = [
+				{ charset: 'utf-8' },
+				{ name: 'viewport', content: 'width=device-width, initial-scale=1' }
+			];
+			
+			/** Merge any passed metadata with the default metadata */
+			if(Array.isArray(config.server.metadata))
+			{
+				mergeMetadata(metadata, config.server.metadata);
+			}
 
 			/** Read client cookie, returns {} when unexisting */
 			const client = cookieRead(req);
@@ -164,10 +174,7 @@ const handle = async (
 							directories: data.contents.directories,
 							files: data.contents.files,
 							metadata: metadata,
-							setMetadata: (data: TMetaData) =>
-							{
-								metadata = data;
-							}
+							setMetadata: (data: TMetaData) => metadata = data
 						});
 					} catch(e) {
 						debug(chalk.red(`Error reading '.ivfi' file: ${e.message} - ignoring file.`));

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,12 +1,5 @@
 doctype html
 head
-  meta(
-    charset='utf-8'
-  )
-  meta(
-    name='viewport'
-    content='width=device-width, initial-scale=1'
-  )
   if (metadata)
     each item in metadata
       meta()&attributes(item)


### PR DESCRIPTION
This PR adds support for directory-specific configurations while also streamlining the previous  `.indexignore` feature into this new feature.

### Usage
If the script detects a dotfile (`.ivfi` file) in the current directory, it'll read and parse its values and apply it to the script. This makes it easy to hide certain files or extensions in a specific directory, set the metadata for a specific directory and so on.

### Example
An example of an `.ivfi` file:
```json
{
    "metadata": [
        { "property": "og:description", "content": "This is a custom description." },
        { "charset": "iso-8859-1" }
    ],
    "metadataBehavior": "overwrite",
    "ignore": ["*.md"],
    "exclude": ["png"]
}
```

`metadataBehavior` can be changed between `overwrite` or `replace`, which respectively either overwrites previous metadata values or replaces them all completely.

`ignore` accepts an array of strings which contains the files to hide. This works in the same way as the previous `.indexignore`.

This feature will still have to be tested a bit, and more options can be added to it.